### PR TITLE
RPM package: change build dependency on python2-docutils to /usr/bin/…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Second, install build dependencies of the collector
     # Optionally: doxygen pkg-config
 
 * Note: latest systems (e.g. Fedora) use ``dnf`` instead of ``yum``.
-* Note: package ``python-docutils`` may by also named as ``python2-docutils``
+* Note: package ``python-docutils`` may by also named as ``python2-docutils`` or ``python3-docutils``
 * Note: package ``pkg-config`` may by also named as ``pkgconfig``
 
 **Debian/Ubuntu:**

--- a/pkg/rpm/ipfixcol2.spec.in
+++ b/pkg/rpm/ipfixcol2.spec.in
@@ -12,7 +12,7 @@ Packager:       @CPACK_PACKAGE_CONTACT@
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
 BuildRequires:  gcc >= 4.8, gcc-c++ >= 4.8, cmake >= 2.8.8, make
-BuildRequires:  libfds-devel, python2-docutils, zlib-devel
+BuildRequires:  libfds-devel, /usr/bin/rst2man, zlib-devel
 Requires:       libfds >= 0.2.0, zlib
 
 %description


### PR DESCRIPTION
…rst2man so that it works better across a variety of distros.