### PR TITLE
Musl patches for 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(CMakeModules/git_info.cmake)
 include(CMakeModules/install_dirs.cmake)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include(CheckSymbolExists)
 
 # Include custom FindXXX modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules")

--- a/src/plugins/output/json/CMakeLists.txt
+++ b/src/plugins/output/json/CMakeLists.txt
@@ -1,3 +1,10 @@
+# Musl support: Check if our pthread library has NP
+set(CMAKE_REQUIRED_LIBRARIES "-pthread")
+check_symbol_exists(pthread_rwlockattr_setkind_np "pthread.h" HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
+if (HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_PTHREAD_RWLOCKATTR_SETKIND_NP")
+endif()
+
 # Create a linkable module
 add_library(json-output MODULE
     src/json.cpp

--- a/src/plugins/output/json/src/File.cpp
+++ b/src/plugins/output/json/src/File.cpp
@@ -110,6 +110,7 @@ File::File(const struct cfg_file &cfg, ipx_ctx_t *ctx) : Output(cfg.name, ctx)
         throw std::runtime_error("(File output) Rwlockattr initialization failed!");
     }
 
+#if defined(HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)
     if (pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP) != 0) {
         if (_thread->m_calg == calg::GZIP) {
             gzclose((gzFile)_thread->file);
@@ -120,6 +121,7 @@ File::File(const struct cfg_file &cfg, ipx_ctx_t *ctx) : Output(cfg.name, ctx)
         delete _thread;
         throw std::runtime_error("(File output) Rwlockattr setkind failed!");
     }
+#endif
 
     if (pthread_rwlock_init(&_thread->rwlock, &attr) != 0) {
         if (_thread->m_calg == calg::GZIP) {

--- a/src/plugins/output/json/src/File.cpp
+++ b/src/plugins/output/json/src/File.cpp
@@ -53,6 +53,7 @@
 #include <unistd.h>
 #include <climits>
 #include <zlib.h>
+#include <locale.h>
 
 /**
  * \brief Class constructor
@@ -342,8 +343,21 @@ File::dir_create(ipx_ctx_t *ctx, const std::string &path)
             continue;
         default:
             // Other errors
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            int errno_save = errno;
+            locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+            const char *err_str;
+            if (loc == (locale_t)0) {
+                if (errno == ENOENT) {
+                    loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+                }
+            }
+            if (loc != (locale_t)0) {
+                err_str = strerror_l(errno_save, loc);
+                freelocale(loc);
+            } else {
+                err_str = "newlocale() failed";
+            }
+            errno = errno_save;
             IPX_CTX_ERROR(ctx, "(File output) Failed to create a directory %s (%s).",
                 aux_str.c_str(), err_str);
             return 1;
@@ -357,8 +371,21 @@ File::dir_create(ipx_ctx_t *ctx, const std::string &path)
 
         if (mkdir(aux_str.c_str(), mask) != 0) {
             // Failed to create directory
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            int errno_save = errno;
+            locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+            const char *err_str;
+            if (loc == (locale_t)0) {
+                if (errno == ENOENT) {
+                    loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+                }
+            }
+            if (loc != (locale_t)0) {
+                err_str = strerror_l(errno_save, loc);
+                freelocale(loc);
+            } else {
+                err_str = "newlocale() failed";
+            }
+            errno = errno_save;
             IPX_CTX_ERROR(ctx, "(File output) Failed to create a directory %s (%s).",
                 aux_str.c_str(), err_str);
             return 1;
@@ -419,8 +446,21 @@ File::file_create(ipx_ctx_t *ctx, const std::string &tmplt, const std::string &p
     }
     if (!file) {
         // Failed to create a flow file
-        char buffer[128];
-        const char *err_str = strerror_r(errno, buffer, 128);
+        int errno_save = errno;
+        locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+        const char *err_str;
+        if (loc == (locale_t)0) {
+            if (errno == ENOENT) {
+                loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+            }
+        }
+        if (loc != (locale_t)0) {
+            err_str = strerror_l(errno_save, loc);
+            freelocale(loc);
+        } else {
+            err_str = "newlocale() failed";
+        }
+        errno = errno_save;
         IPX_CTX_ERROR(ctx, "Failed to create a flow file '%s' (%s).", file_name.c_str(), err_str);
         return NULL;
     }

--- a/src/plugins/output/json/src/Server.cpp
+++ b/src/plugins/output/json/src/Server.cpp
@@ -47,6 +47,7 @@
 #include <sys/time.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <locale.h>
 
 /** How many pending connections queue will hold */
 #define BACKLOG (10)
@@ -201,8 +202,21 @@ Server::thread_accept(void *context)
                 continue;
             }
 
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            int errno_save = errno;
+            locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+            const char *err_str;
+            if (loc == (locale_t)0) {
+                if (errno == ENOENT) {
+                    loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+                }
+            }
+            if (loc != (locale_t)0) {
+                err_str = strerror_l(errno_save, loc);
+                freelocale(loc);
+            } else {
+                err_str = "newlocale() failed";
+            }
+            errno = errno_save;
             IPX_CTX_ERROR(acc->ctx, "(Server output) select() - failed (%s)", err_str);
             break;
         }
@@ -214,8 +228,21 @@ Server::thread_accept(void *context)
 
         new_fd = accept(acc->socket_fd, (struct sockaddr *) &client_addr, &sin_size);
         if (new_fd == -1) {
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            int errno_save = errno;
+            locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+            const char *err_str;
+            if (loc == (locale_t)0) {
+                if (errno == ENOENT) {
+                    loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+                }
+            }
+            if (loc != (locale_t)0) {
+                err_str = strerror_l(errno_save, loc);
+                freelocale(loc);
+            } else {
+                err_str = "newlocale() failed";
+            }
+            errno = errno_save;
             IPX_CTX_ERROR(acc->ctx, "(Server output) accept() - failed (%s)", err_str);
             continue;
         }
@@ -270,8 +297,21 @@ Server::msg_send(const char *data, ssize_t len, client_t &client)
             }
 
             // Connection failed
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            int errno_save = errno;
+            locale_t loc = newlocale(LC_MESSAGES_MASK, "", (locale_t)0);
+            const char *err_str;
+            if (loc == (locale_t)0) {
+                if (errno == ENOENT) {
+                    loc = newlocale(LC_MESSAGES_MASK, "POSIX", (locale_t)0);
+                }
+            }
+            if (loc != (locale_t)0) {
+                err_str = strerror_l(errno_save, loc);
+                freelocale(loc);
+            } else {
+                err_str = "newlocale() failed";
+            }
+            errno = errno_save;
             IPX_CTX_INFO(_ctx, "(Server output) Client disconnected: %s (%s)",
                 get_client_desc(client.info).c_str(), err_str);
             return SEND_FAILED;


### PR DESCRIPTION
Hello again:

We have various build targets with different archs, C libraries, etc.  Most of them use Musl, but one of the ARM boards this is targeted for actually does use traditional glibc.  Everything I add also has to work for our 32- and 64-bit simulation environments as well.

These are the cross-compile targets I'm working with:
1) arm-glibc
2) x86-musl
3) x86_64-musl

There are 2 commits here.

**The first commit addresses the usage of pthread NP:**

In applying the same kind of Musl patch for 'libnetconf2', https://github.com/CESNET/libnetconf2/commit/153fe40bd60499677e825e66501e8601536e0323 , I noticed that it actually doesn't work.  `check_function_exists(pthread_rwlockattr_setkind_np HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP)` returns false / 'not found' on that arm-glibc target, which definitely does have it in that toolchain's "pthread.h" file.

So I ended up writing a patch for 'IPFIXcol2' that uses the slightly different CMake `check_symbol_exists`, which is actually recommended as a replacement by CMake.  See note at the bottom of their docs here:  https://cmake.org/cmake/help/latest/module/CheckFunctionExists.html 

You might want to do a similar change in your 'libnetconf2'

arm-glibc target now:
```
-- The C compiler identification is GNU 5.5.0
-- The CXX compiler identification is GNU 5.5.0
...
-- Found LibFds: /mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/lib/libfds.so (found suitable version "0.2.0", minimum required is "0.2.0") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - not found
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- Looking for pthread_rwlockattr_setkind_np
-- Looking for pthread_rwlockattr_setkind_np - found
-- Found ZLIB: /mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/lib/libz.so (found version "1.2.11") 
...
[ 75%] Building CXX object src/plugins/output/json/CMakeFiles/json-output.dir/src/File.cpp.o
cd /mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json && /usr/bin/ccache /opt/toolchains/crosstools-arm-gcc-5.5-linux-4.1-glibc-2.26-binutils-2.28.1/bin/arm-buildroot-linux-gnueabi-g++  -Djson_output_EXPORTS -I/mnt/ipfixcol2.2.1.0-patch/include -I/mnt/ipfixcol2.2.1.0-patch/src -I/mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/include  -Os -pipe -g3 -fno-caller-saves -rdynamic -DNGX -I/mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/include -I/opt/toolchains/crosstools-arm-gcc-5.5-linux-4.1-glibc-2.26-binutils-2.28.1/arm-buildroot-linux-gnueabi/include -I/opt/toolchains/crosstools-arm-gcc-5.5-linux-4.1-glibc-2.26-binutils-2.28.1/arm-buildroot-linux-gnueabi/sysroot/usr/include -fvisibility=hidden -std=gnu++11 -DHAVE_PTHREAD_RWLOCKATTR_SETKIND_NP -O2 -DNDEBUG -fPIC   -o CMakeFiles/json-output.dir/src/File.cpp.o -c /mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json/src/File.cpp
```
Notice it adds `-DHAVE_PTHREAD_RWLOCKATTR_SETKIND_NP` to CFLAGS.  I don't know if this was the best way to do it or not.


x86_64-musl target now:
```
-- The C compiler identification is GNU 7.3.0
-- The CXX compiler identification is GNU 7.3.0
...
-- Found LibFds: /mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/lib/libfds.so (found suitable version "0.2.0", minimum required is "0.2.0") 
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Threads: TRUE  
-- Looking for pthread_rwlockattr_setkind_np
-- Looking for pthread_rwlockattr_setkind_np - not found
-- Found ZLIB: /mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/lib/libz.so (found version "1.2.11") 
...
[ 75%] Building CXX object src/plugins/output/json/CMakeFiles/json-output.dir/src/File.cpp.o
cd /mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json && /usr/bin/ccache /opt/toolchains/bin/x86_64-openwrt-linux-musl-g++  -Djson_output_EXPORTS -I/mnt/ipfixcol2.2.1.0-patch/include -I/mnt/ipfixcol2.2.1.0-patch/src -I/mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/include  -Os -pipe -fno-caller-saves -g3 -rdynamic -fhonour-copts -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -Wno-error=unused-const-variable -I/opt/toolchains/include -I/mnt/ipfixcol2.2.1.0-patch/.odedeps/usr/include -I/opt/toolchains/x86_64-openwrt-linux-musl/include -fvisibility=hidden -std=gnu++11 -O2 -DNDEBUG -fPIC   -o CMakeFiles/json-output.dir/src/File.cpp.o -c /mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json/src/File.cpp
```

**The second commit addresses the usage of `strerror_r`:**

From manpage of 'strerror' group:  https://man7.org/linux/man-pages/man3/strerror.3.html  There are 2 signatures of `strerror_r`:  XSI and GNU.  Musl does not do _any_ GNU extensions, so it only provides the XSI signature returning an `int`.  `strerror_r` is considered non-portable and deprecated anyways, so replace with `strerror_l`.

"libnl" did something similar:  https://lists.infradead.org/pipermail/libnl/2016-August/002196.html 

```
/mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json/src/File.cpp: In static member function 'static int File::dir_create(ipx_ctx_t*, const string&)':
/mnt/ipfixcol2.2.1.0-patch/src/plugins/output/json/src/File.cpp:346:45: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
             const char *err_str = strerror_r(errno, buffer, 128);
                                   ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
```

With these 2 commits, I can successfully build for all my targets, and I'll consider that it fixes #34 