### PR TITLE
BSD support

### DIFF
--- a/CMakeModules/FindLibEpollShim.cmake
+++ b/CMakeModules/FindLibEpollShim.cmake
@@ -1,0 +1,40 @@
+#  LIBEPOLLSHIM_FOUND - System has libepoll-shim
+#  LIBEPOLLSHIM_INCLUDE_DIRS - The libepoll-shim include directories
+#  LIBEPOLLSHIM_LIBRARIES - The libraries needed to use libepoll-shim
+#  LIBEPOLLSHIM_DEFINITIONS - Compiler switches required for using libepoll-shim
+
+# use pkg-config to get the directories and then use these values
+# in the find_path() and find_library() calls
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_EPOLLSHIM QUIET epoll-shim)
+    set(LIBEPOLLSHIM_DEFINITIONS ${PC_EPOLLSHIM_CFLAGS_OTHER})
+endif()
+
+find_path(
+    EPOLLSHIM_INCLUDE_DIR libepoll-shim/sys/epoll.h
+    HINTS ${PC_EPOLLSHIM_INCLUDEDIR} ${PC_EPOLLSHIM_INCLUDE_DIRS}
+    PATH_SUFFIXES include
+)
+find_library(
+    EPOLLSHIM_LIBRARY NAMES epoll-shim libepoll-shim
+    HINTS ${PC_EPOLLSHIM_LIBDIR} ${PC_EPOLLSHIM_LIBRARY_DIRS}
+    PATH_SUFFIXES lib lib64
+)
+
+if (PC_EPOLLSHIM_VERSION)
+    # Version extracted from pkg-config
+    set(EPOLLSHIM_VERSION_STRING ${PC_EPOLLSHIM_VERSION})
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set LIBEPOLLSHIM_FOUND to TRUE
+# if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibEpollShim
+    REQUIRED_VARS EPOLLSHIM_LIBRARY EPOLLSHIM_INCLUDE_DIR
+    VERSION_VAR EPOLLSHIM_VERSION_STRING
+)
+
+set(LIBEPOLLSHIM_LIBRARIES ${EPOLLSHIM_LIBRARY})
+set(LIBEPOLLSHIM_INCLUDE_DIRS ${EPOLLSHIM_INCLUDE_DIR}/libepoll-shim)
+mark_as_advanced(EPOLLSHIM_INCLUDE_DIR EPOLLSHIM_LIBRARY)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -79,6 +79,10 @@ target_link_libraries(ipfixcol2base
 
 # Build IPFIXCOL2 exacutable with all symbols from the base library
 set(BASE_LIB -Wl,--whole-archive ipfixcol2base -Wl,--no-whole-archive)
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_HOST_SYSTEM_NAME STREQUAL "OpenBSD")
+    set(BASE_LIB ${BASE_LIB} -rdynamic)
+endif()
+
 add_executable(ipfixcol2 main.cpp)
 target_link_libraries(ipfixcol2 ${BASE_LIB})
 set_target_properties(ipfixcol2 PROPERTIES  # by default, hide all symbols

--- a/src/core/configurator/cpipe.c
+++ b/src/core/configurator/cpipe.c
@@ -9,6 +9,7 @@
  */
 
 
+#include <assert.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>

--- a/src/core/context.c
+++ b/src/core/context.c
@@ -45,7 +45,11 @@
 #include <pthread.h>
 #include <errno.h>
 #include <signal.h>
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+#include <pthread_np.h>
+#else
 #include <sys/prctl.h>
+#endif
 
 #include "context.h"
 #include "extension.h"
@@ -640,6 +644,9 @@ thread_set_name(const char *ident)
     strncpy(name, ident, size - 1);
     name[size - 1] = '\0';
 
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+    pthread_set_name_np(pthread_self(), name);
+#else
     int rc = prctl(PR_SET_NAME, name, 0, 0, 0);
     if (rc == -1) {
         const char *err_str;
@@ -647,6 +654,7 @@ thread_set_name(const char *ident)
         IPX_WARNING(comp_str, "Failed to set the name of a thread. prctl() failed: %s",
             err_str);
     }
+#endif
 }
 
 /**
@@ -656,6 +664,9 @@ thread_set_name(const char *ident)
 static inline void
 thread_get_name(char ident[16])
 {
+#if defined(__OpenBSD__) || defined(__FreeBSD__)
+    pthread_get_name_np(pthread_self(), ident, 16);
+#else
     int rc = prctl(PR_GET_NAME, ident, 0, 0, 0);
     if (rc == -1) {
         const char *err_str;
@@ -664,6 +675,7 @@ thread_get_name(char ident[16])
             err_str);
         ident[0] = '\0';
     }
+#endif
 }
 
 int

--- a/src/core/message_ipfix.c
+++ b/src/core/message_ipfix.c
@@ -39,6 +39,7 @@
  *
  */
 
+#include <assert.h>
 #include <ipfixcol2.h>
 #include <libfds.h>
 #include "message_base.h"

--- a/src/core/message_terminate.c
+++ b/src/core/message_terminate.c
@@ -39,6 +39,7 @@
  *
  */
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include "message_terminate.h"

--- a/src/core/netflow2ipfix/netflow5.c
+++ b/src/core/netflow2ipfix/netflow5.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <endian.h>

--- a/src/core/netflow2ipfix/netflow9.c
+++ b/src/core/netflow2ipfix/netflow9.c
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <endian.h>
 #include <assert.h>

--- a/src/core/odid_range.c
+++ b/src/core/odid_range.c
@@ -39,6 +39,7 @@
  *
  */
 
+#include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>

--- a/src/core/session.c
+++ b/src/core/session.c
@@ -39,14 +39,35 @@
  *
  */
 
-// Get GNU specific basename() function
-#define _GNU_SOURCE
 #include <string.h>
 
 #include <stdint.h>
 #include <ipfixcol2.h>
 #include <stdlib.h>
 #include <inttypes.h>
+
+/**
+ * \brief Return the name part of a file path, i.e. the part after the last /
+ * \param path  The file path
+ * \return The name part of the path or NULL if path is NULL
+ */
+static const char *get_basename(const char *path)
+{
+    if (path == NULL) {
+        return NULL;
+    }
+
+    const char *res = path;
+    const char *p = path;
+    while (*p != '\0') {
+        if (*p == '/') {
+            res = p + 1;
+        }
+        p++;
+    }
+
+    return res;
+}
 
 /**
  * \brief Create a source description string from a Network Session structure
@@ -166,7 +187,9 @@ ipx_session_new_file(const char *file_path)
         return NULL;
     }
 
-    res->ident = basename(res->file.file_path); // GNU specific basename()
+    res->ident = res->file.file_path;
+
+    res->ident = (char *) get_basename(res->file.file_path);
     if (!res->ident) {
         free(res);
         return NULL;

--- a/src/plugins/input/fds/Reader.cpp
+++ b/src/plugins/input/fds/Reader.cpp
@@ -47,6 +47,22 @@
 #include "Exception.hpp"
 #include "Reader.hpp"
 
+static inline bool in6_is_addr_v4mapped(const uint8_t addr[16])
+{
+    return
+        addr[0] == 0 &&
+        addr[1] == 0 &&
+        addr[2] == 0 &&
+        addr[3] == 0 &&
+        addr[4] == 0 &&
+        addr[5] == 0 &&
+        addr[6] == 0 &&
+        addr[7] == 0 &&
+        addr[8] == 0 &&
+        addr[9] == 0 &&
+        addr[10] == 0xFF &&
+        addr[11] == 0xFF;
+}
 
 Reader::Reader(ipx_ctx_t *ctx, const fds_config *cfg, const char *path)
     : m_ctx(ctx), m_cfg(cfg)
@@ -97,7 +113,7 @@ Reader::session_from_sid(fds_file_sid_t sid)
     memset(&session_net, 0, sizeof(session_net));
     session_net.port_src = desc->port_src;
     session_net.port_dst = desc->port_dst;
-    if (IN6_IS_ADDR_V4MAPPED(desc->ip_src) && IN6_IS_ADDR_V4MAPPED(desc->ip_dst)) {
+    if (in6_is_addr_v4mapped(desc->ip_src) && in6_is_addr_v4mapped(desc->ip_dst)) {
         session_net.l3_proto = AF_INET;
         session_net.addr_src.ipv4 = *reinterpret_cast<const struct in_addr *>(&desc->ip_src[12]);
         session_net.addr_dst.ipv4 = *reinterpret_cast<const struct in_addr *>(&desc->ip_dst[12]);

--- a/src/plugins/input/fds/fds.cpp
+++ b/src/plugins/input/fds/fds.cpp
@@ -110,6 +110,9 @@ file_is_dir(const char *filename)
 void
 file_list_init(Instance *inst, const char *pattern)
 {
+#ifndef GLOB_TILDE_CHECK
+#define GLOB_TILDE_CHECK GLOB_TILDE
+#endif
     int glob_flags = GLOB_MARK | GLOB_BRACE | GLOB_TILDE_CHECK;
     size_t file_cnt;
     int ret;

--- a/src/plugins/input/ipfix/ipfix.c
+++ b/src/plugins/input/ipfix/ipfix.c
@@ -132,6 +132,9 @@ static inline int
 files_list_get(ipx_ctx_t *ctx, const char *pattern, glob_t *list)
 {
     size_t file_cnt;
+#ifndef GLOB_TILDE_CHECK
+#define GLOB_TILDE_CHECK GLOB_TILDE
+#endif
     int glob_flags = GLOB_MARK | GLOB_BRACE | GLOB_TILDE_CHECK;
     int rc = glob(pattern, glob_flags, NULL, list);
 

--- a/src/plugins/input/tcp/CMakeLists.txt
+++ b/src/plugins/input/tcp/CMakeLists.txt
@@ -5,6 +5,16 @@ add_library(tcp-input MODULE
     config.h
 )
 
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_HOST_SYSTEM_NAME STREQUAL "OpenBSD")
+    find_package(LibEpollShim REQUIRED)
+    include_directories(
+        ${LIBEPOLLSHIM_INCLUDE_DIRS}
+    )
+    target_link_libraries(tcp-input
+        ${LIBEPOLLSHIM_LIBRARIES}
+    )
+endif()
+
 install(
     TARGETS tcp-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/input/udp/CMakeLists.txt
+++ b/src/plugins/input/udp/CMakeLists.txt
@@ -5,6 +5,16 @@ add_library(udp-input MODULE
     config.h
 )
 
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_HOST_SYSTEM_NAME STREQUAL "OpenBSD")
+    find_package(LibEpollShim REQUIRED)
+    include_directories(
+        ${LIBEPOLLSHIM_INCLUDE_DIRS}
+    )
+    target_link_libraries(udp-input
+        ${LIBEPOLLSHIM_LIBRARIES}
+    )
+endif()
+
 install(
     TARGETS udp-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/output/forwarder/src/Config.cpp
+++ b/src/plugins/output/forwarder/src/Config.cpp
@@ -46,6 +46,8 @@
 #include <cstring>
 #include <netdb.h>
 #include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 ///
 /// Config schema definition

--- a/src/plugins/output/forwarder/src/Connection.cpp
+++ b/src/plugins/output/forwarder/src/Connection.cpp
@@ -39,6 +39,7 @@
  *
  */
 
+#include <sys/socket.h>
 #include "Connection.h"
 
 #include <stdexcept>

--- a/src/plugins/output/forwarder/src/main.cpp
+++ b/src/plugins/output/forwarder/src/main.cpp
@@ -39,6 +39,7 @@
  *
  */
 
+#include <sys/socket.h>
 #include "Forwarder.h"
 #include "Config.h"
 

--- a/src/plugins/output/json-kafka/src/Kafka.hpp
+++ b/src/plugins/output/json-kafka/src/Kafka.hpp
@@ -48,6 +48,7 @@
 #include <ctime>
 #include <memory>
 #include <librdkafka/rdkafka.h>
+#include <pthread.h>
 
 /** JSON kafka connector */
 class Kafka : public Output {

--- a/src/plugins/output/json/src/File.cpp
+++ b/src/plugins/output/json/src/File.cpp
@@ -110,6 +110,9 @@ File::File(const struct cfg_file &cfg, ipx_ctx_t *ctx) : Output(cfg.name, ctx)
         throw std::runtime_error("(File output) Rwlockattr initialization failed!");
     }
 
+#ifdef PTHREAD_RWLOCK_WRITER_NONRECURSIVE_INITIALIZER_NP
+    // PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP avoids writer starvation
+    // It is a non-portable GNU extension only available on Linux systems
     if (pthread_rwlockattr_setkind_np(&attr, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP) != 0) {
         if (_thread->m_calg == calg::GZIP) {
             gzclose((gzFile)_thread->file);
@@ -120,6 +123,7 @@ File::File(const struct cfg_file &cfg, ipx_ctx_t *ctx) : Output(cfg.name, ctx)
         delete _thread;
         throw std::runtime_error("(File output) Rwlockattr setkind failed!");
     }
+#endif
 
     if (pthread_rwlock_init(&_thread->rwlock, &attr) != 0) {
         if (_thread->m_calg == calg::GZIP) {

--- a/src/plugins/output/json/src/File.cpp
+++ b/src/plugins/output/json/src/File.cpp
@@ -344,8 +344,8 @@ File::dir_create(ipx_ctx_t *ctx, const std::string &path)
             continue;
         default:
             // Other errors
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_ERROR(ctx, "(File output) Failed to create a directory %s (%s).",
                 aux_str.c_str(), err_str);
             return 1;
@@ -359,8 +359,8 @@ File::dir_create(ipx_ctx_t *ctx, const std::string &path)
 
         if (mkdir(aux_str.c_str(), mask) != 0) {
             // Failed to create directory
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_ERROR(ctx, "(File output) Failed to create a directory %s (%s).",
                 aux_str.c_str(), err_str);
             return 1;
@@ -421,8 +421,8 @@ File::file_create(ipx_ctx_t *ctx, const std::string &tmplt, const std::string &p
     }
     if (!file) {
         // Failed to create a flow file
-        char buffer[128];
-        const char *err_str = strerror_r(errno, buffer, 128);
+        const char *err_str;
+        ipx_strerror(errno, err_str);
         IPX_CTX_ERROR(ctx, "Failed to create a flow file '%s' (%s).", file_name.c_str(), err_str);
         return NULL;
     }

--- a/src/plugins/output/json/src/Kafka.hpp
+++ b/src/plugins/output/json/src/Kafka.hpp
@@ -48,6 +48,7 @@
 #include <ctime>
 #include <memory>
 #include <librdkafka/rdkafka.h>
+#include <pthread.h>
 
 /** JSON kafka connector */
 class Kafka : public Output {

--- a/src/plugins/output/json/src/Sender.cpp
+++ b/src/plugins/output/json/src/Sender.cpp
@@ -39,11 +39,13 @@
  *
  */
 
+#include <ipfixcol2.h>
 #include "Sender.hpp"
 
 #include <time.h>
 #include <unistd.h>
 #include <inttypes.h>
+#include <cerrno>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -229,8 +231,8 @@ Sender::send(const char *str, size_t len)
             }
 
             // Connection failed
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_INFO(_ctx, "(Send output) Destination '%s:%" PRIu16 "' disconnected: %s",
                 params.addr.c_str(), params.port, err_str);
             return SEND_FAILED;

--- a/src/plugins/output/json/src/Server.cpp
+++ b/src/plugins/output/json/src/Server.cpp
@@ -37,9 +37,12 @@
  *
  */
 
+#include <ipfixcol2.h>
 #include "Server.hpp"
+
 #include <stdexcept>
 #include <cstring>
+#include <cerrno>
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -201,8 +204,8 @@ Server::thread_accept(void *context)
                 continue;
             }
 
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_ERROR(acc->ctx, "(Server output) select() - failed (%s)", err_str);
             break;
         }
@@ -214,8 +217,8 @@ Server::thread_accept(void *context)
 
         new_fd = accept(acc->socket_fd, (struct sockaddr *) &client_addr, &sin_size);
         if (new_fd == -1) {
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_ERROR(acc->ctx, "(Server output) accept() - failed (%s)", err_str);
             continue;
         }
@@ -270,8 +273,8 @@ Server::msg_send(const char *data, ssize_t len, client_t &client)
             }
 
             // Connection failed
-            char buffer[128];
-            const char *err_str = strerror_r(errno, buffer, 128);
+            const char *err_str;
+            ipx_strerror(errno, err_str);
             IPX_CTX_INFO(_ctx, "(Server output) Client disconnected: %s (%s)",
                 get_client_desc(client.info).c_str(), err_str);
             return SEND_FAILED;

--- a/src/plugins/output/json/src/Syslog.cpp
+++ b/src/plugins/output/json/src/Syslog.cpp
@@ -49,6 +49,10 @@
 
 #include "Syslog.hpp"
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 /** Delay between reconnection attempts (seconds)  */
 #define RECONN_DELAY (5)
 /** How ofter to report statistics (seconds) */

--- a/src/plugins/output/json/src/SyslogSocket.cpp
+++ b/src/plugins/output/json/src/SyslogSocket.cpp
@@ -40,6 +40,7 @@
  */
 
 #include <cassert>
+#include <cstring>
 #include <stdexcept>
 
 #include <netdb.h>

--- a/src/tools/fdsdump/src/aggregator/print.cpp
+++ b/src/tools/fdsdump/src/aggregator/print.cpp
@@ -8,6 +8,7 @@
 
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <sys/socket.h>
 
 #include <cctype>
 

--- a/src/tools/fdsdump/src/common/ipaddr.cpp
+++ b/src/tools/fdsdump/src/common/ipaddr.cpp
@@ -1,5 +1,7 @@
 
 #include <stdexcept>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include "ipaddr.hpp"
 
 namespace fdsdump {

--- a/src/tools/ipfixsend/ipfixsend.c
+++ b/src/tools/ipfixsend/ipfixsend.c
@@ -46,7 +46,9 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#ifdef __linux__
 #include <linux/sockios.h>
+#endif
 #include <time.h>
 
 #include "siso.h"
@@ -268,6 +270,9 @@ int main(int argc, char** argv)
     // Make sure that all packets are delivered before socket closes
     int socket_fd = siso_get_socket(sender);
     int not_sent = 0;
+#ifndef SIOCOUTQ
+#define SIOCOUTQ TIOCOUTQ
+#endif
     while (!stop && ioctl(socket_fd, SIOCOUTQ, &not_sent) != -1) {
         if (not_sent <= 0) {
             break;

--- a/src/tools/ipfixsend/siso.c
+++ b/src/tools/ipfixsend/siso.c
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 
 #include <sys/time.h>
 #include <time.h>


### PR DESCRIPTION
Modifications to make ipfixcol2 buildable on BSD systems (tested on FreeBSD 15)

Building with Clang is recommended, as GCC seems to cause some issues 

