### PR TITLE
core: fix includes in utils.c causing compilation failure because of undefined be64toh/htobe64

### DIFF
--- a/src/core/utils.c
+++ b/src/core/utils.c
@@ -46,10 +46,13 @@
 
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
-#include "utils.h"
+#include <ipfixcol2/api.h>
 
 
 int

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -45,8 +45,6 @@
 extern "C" {
 #endif
 
-#include <ipfixcol2.h>
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
`#include <ipfixcol2.h>` resulted in including a file in which be64toh/htobe64 functions were used. This would clash with the defines present here that are necessary to get the wanted strerror_r function, resulting in the be64toh/htobe64 functions being undefined.

This was fixed by not including ipfixcol2.h as a whole, but only the necessary part, as well as adding explicit includes for the system headers that were brought by ipfixcol2.h.