### PR TITLE
fix: undefined symbols from ipfixcol2core lib in some plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.22)
 project(ipfixcol2)
 
 # Description of the project

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -68,6 +68,8 @@ set(CORE_SOURCE
 
 # Create a static library from all source code (useful for building
 # the main application and unit tests separately)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 add_library(
     ipfixcol2base STATIC
     ${CORE_SOURCE}

--- a/src/plugins/input/dummy/CMakeLists.txt
+++ b/src/plugins/input/dummy/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(dummy-input MODULE
     config.h
 )
 
+target_link_libraries(dummy-input
+    ipfixcol2base               # Link against the core library
+)
+
 install(
     TARGETS dummy-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/input/fds/CMakeLists.txt
+++ b/src/plugins/input/fds/CMakeLists.txt
@@ -10,6 +10,10 @@ add_library(fds-input MODULE
     Reader.hpp
 )
 
+target_link_libraries(fds-input
+    ipfixcol2base               # Link against the core library
+)
+
 install(
     TARGETS fds-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/input/ipfix/CMakeLists.txt
+++ b/src/plugins/input/ipfix/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(ipfix-input MODULE
     config.h
 )
 
+target_link_libraries(ipfix-input
+    ipfixcol2base               # Link against the core library
+)
+
 install(
     TARGETS ipfix-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/input/tcp/CMakeLists.txt
+++ b/src/plugins/input/tcp/CMakeLists.txt
@@ -29,6 +29,10 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_HOST_SYSTEM_NAME STREQUAL
     )
 endif()
 
+target_link_libraries(tcp-input
+    ipfixcol2base               # Link against the core library
+)
+
 install(
     TARGETS tcp-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/input/udp/CMakeLists.txt
+++ b/src/plugins/input/udp/CMakeLists.txt
@@ -15,6 +15,10 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_HOST_SYSTEM_NAME STREQUAL
     )
 endif()
 
+target_link_libraries(udp-input
+    ipfixcol2base               # Link against the core library
+)
+
 install(
     TARGETS udp-input
     LIBRARY DESTINATION "${INSTALL_DIR_LIB}/ipfixcol2/"

--- a/src/plugins/output/json/CMakeLists.txt
+++ b/src/plugins/output/json/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
     ${LIBRDKAFKA_INCLUDE_DIRS}   # librdkafka
 )
 target_link_libraries(json-output
+    ipfixcol2base               # Link against the core library
     ${ZLIB_LIBRARIES}
     ${LIBRDKAFKA_LIBRARIES}
 )


### PR DESCRIPTION
ipfixcol2 -c udp2json.xml ERROR: Configurator: Collector failed to start: Failed to load a plugin from '/usr/local/lib/ipfixcol2/libjson-output.so': /usr/local/lib/ipfixcol2/libjson-output.so: undefined symbol: ipx_msg_ipfix_get_drec

libjson-output.so plugin for ipfixcol2 is unable to find the symbol ipx_msg_ipfix_get_drec
also other plugins is unable to find some symbols from ipfixcol2core lib.