### PR TITLE
Clickhouse - ignore records using options templates

### DIFF
--- a/extra_plugins/output/clickhouse/src/plugin.cpp
+++ b/extra_plugins/output/clickhouse/src/plugin.cpp
@@ -144,6 +144,13 @@ void Plugin::extract_values(ipx_msg_ipfix_t *msg, RecParser &parser, Block &bloc
 int
 Plugin::process_record(ipx_msg_ipfix_t *msg, fds_drec &rec, Block &block)
 {
+    if (rec.tmplt->type == FDS_TYPE_TEMPLATE_OPTS) {
+        // skip the data record if the template used is a options template
+        // currently we only want data records using "normal" templates
+        // this is to prevent empty records in the database and might be improved upon in the future
+        return 0;
+    }
+
     int ret = 0;
     RecParser &parser = m_rec_parsers->get_parser(rec.tmplt);
     parser.parse_record(rec);


### PR DESCRIPTION
Records using options templates would result in empty rows in the database because no data field would match.

Currently we will just ignore them.

Sometime in the future, if someone needs it, we can skip empty records to prevent them from being inserted instead and allow for options template records to also be stored.