### PR TITLE
Bumping cmake_minimum_required to fix FTBFS with cmake 4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.5)
 project(ipfixcol2)
 
 # Description of the project


### PR DESCRIPTION
Hi,

cmake 4 raised the minimum feature baseline for cmakefiles, ipfixcol2 does meet all of them, however, it makes sense to set it to the lowest number of the syntax that cmake 4 supports for maximum compatibility.

This is the patch we've applied in Debian, it would be nice if you could merge it.

Regards,
Daniel